### PR TITLE
fix: support kube_version for cluster resource

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,17 +3,20 @@ HOSTNAME=symbiosis.host
 NAMESPACE=symbiosis
 NAME=symbiosis
 BINARY=terraform-provider-${NAME}
-VERSION=0.1
+VERSION=0.2
 OS_ARCH=darwin_arm64
 
 default: install
 
+.PHONY: build
 build:
 	go build -o ${BINARY}
 
+.PHONY: docs
 docs:
 	tfplugindocs
 
+.PHONY: release
 release:
 	GOOS=darwin GOARCH=arm64 go build -o ./bin/${BINARY}_${VERSION}_darwin_arm64
 	GOOS=freebsd GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_freebsd_386
@@ -28,13 +31,15 @@ release:
 	GOOS=windows GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_windows_386
 	GOOS=windows GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_windows_amd64
 
+.PHONY: build
 install: build
 	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
 	mv ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
 
+.PHONY: test
 test: 
 	go test -i $(TEST) || exit 1                                                   
 	echo $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4                    
-
+.PHONY: testacc
 testacc: 
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m   

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -31,6 +31,7 @@ resource "symbiosis_cluster" "example" {
 
 - **configuration** (Block Set) (see [below for nested schema](#nestedblock--configuration))
 - **id** (String) The ID of this resource.
+- **kube_version** (String) Kubernetes version, see symbiosis.host for valid values or "latest" for the most recent supported version.
 - **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - **wait_until_initialized** (Boolean) Wait until Kubernetes cluster is initialized.
 

--- a/symbiosis/resource_cluster.go
+++ b/symbiosis/resource_cluster.go
@@ -18,55 +18,62 @@ func ResourceCluster() *schema.Resource {
 		Description: `
     Manages Kubernetes clusters.
     `,
-    CreateContext: resourceClusterCreate,
-    ReadContext:   resourceClusterRead,
-    DeleteContext: resourceClusterDelete,
-    Schema: map[string]*schema.Schema{
-      "name": {
-        Type:        schema.TypeString,
-        Required:    true,
-        ForceNew:    true,
-        Description: "Cluster name. Changing the name forces re-creation.",
-      },
-      "region": {
-        Type:        schema.TypeString,
-        Required:    true,
-        ForceNew:    true,
-        Description: "Cluster region, valid values: [eu-germany-1].",
-      },
-      "wait_until_initialized": {
-        Type:        schema.TypeBool,
-        Default:     false,
-        ForceNew:    true,
-        Optional:    true,
-        Description: "Wait until Kubernetes cluster is initialized.",
-      },
-      "configuration": {
-        Type:     schema.TypeSet,
-        ForceNew: true,
-        Optional: true,
-        Elem: &schema.Resource{
-          Schema: map[string]*schema.Schema{
-            "enable_nginx_ingress": {
-              Type:     schema.TypeBool,
-              Default:  false,
-              ForceNew: true,
-              Optional: true,
-            },
-            "enable_csi_driver": {
-              Type:     schema.TypeBool,
-              Default:  false,
-              ForceNew: true,
-              Optional: true,
-            },
-          },
-        },
-      },
-    },
-    Timeouts: &schema.ResourceTimeout{
-      Create: schema.DefaultTimeout(10 * time.Minute),
-    },
-  }
+		CreateContext: resourceClusterCreate,
+		ReadContext:   resourceClusterRead,
+		DeleteContext: resourceClusterDelete,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Cluster name. Changing the name forces re-creation.",
+			},
+			"kube_version": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Default:     "latest",
+				Description: "Kubernetes version, see symbiosis.host for valid values or \"latest\" for the most recent supported version.",
+			},
+			"region": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Cluster region, valid values: [eu-germany-1].",
+			},
+			"wait_until_initialized": {
+				Type:        schema.TypeBool,
+				Default:     false,
+				ForceNew:    true,
+				Optional:    true,
+				Description: "Wait until Kubernetes cluster is initialized.",
+			},
+			"configuration": {
+				Type:     schema.TypeSet,
+				ForceNew: true,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enable_nginx_ingress": {
+							Type:     schema.TypeBool,
+							Default:  false,
+							ForceNew: true,
+							Optional: true,
+						},
+						"enable_csi_driver": {
+							Type:     schema.TypeBool,
+							Default:  false,
+							ForceNew: true,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+		},
+	}
 }
 
 type ClusterNodeInput struct {
@@ -80,10 +87,11 @@ type ClusterConfigurationInput struct {
 }
 
 type PostClusterInput struct {
-  Name          string                    `json:"name"`
-  Region        string                    `json:"regionName"`
-  Nodes         []ClusterNodeInput        `json:"nodes"`
-  Configuration ClusterConfigurationInput `json:"configuration"`
+	Name          string                    `json:"name"`
+	KubeVersion   string                    `json:"kubeVersion"`
+	Region        string                    `json:"regionName"`
+	Nodes         []ClusterNodeInput        `json:"nodes"`
+	Configuration ClusterConfigurationInput `json:"configuration"`
 }
 
 type PostClusterPayload struct {
@@ -96,61 +104,62 @@ type PutNodePoolByTypeInput struct {
 }
 
 func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-  log.Printf("[DEBUG] Creating cluster: %s", d.Get("name").(string))
-  var diags diag.Diagnostics
-  client := meta.(*SymbiosisClient)
-  api := client.symbiosisApi
+	log.Printf("[DEBUG] Creating cluster: %s", d.Get("name").(string))
+	var diags diag.Diagnostics
+	client := meta.(*SymbiosisClient)
+	api := client.symbiosisApi
 
-  configurationInput := ClusterConfigurationInput{
-    EnableCsiDriver:    d.Get("configuration.0.enable_csi_driver").(bool),
-    EnableNginxIngress: d.Get("configuration.0.enable_nginx_ingress").(bool),
-  }
+	configurationInput := ClusterConfigurationInput{
+		EnableCsiDriver:    d.Get("configuration.0.enable_csi_driver").(bool),
+		EnableNginxIngress: d.Get("configuration.0.enable_nginx_ingress").(bool),
+	}
 
-  input := &PostClusterInput{
-    Name:          d.Get("name").(string),
-    Region:        d.Get("region").(string),
-    Nodes:         []ClusterNodeInput{},
-    Configuration: configurationInput,
-  }
+	input := &PostClusterInput{
+		Name:          d.Get("name").(string),
+		Region:        d.Get("region").(string),
+		KubeVersion:   d.Get("kube_version").(string),
+		Nodes:         []ClusterNodeInput{},
+		Configuration: configurationInput,
+	}
 
-  resp, err := api.R().SetBody(input).SetResult(PostClusterPayload{}).SetError(SymbiosisApiError{}).ForceContentType("application/json").Post("rest/v1/cluster")
-  if err != nil {
-    return diag.FromErr(err)
-  }
-  if resp.StatusCode() != 200 {
-    symbiosisErr := resp.Error().(*SymbiosisApiError)
-    if symbiosisErr.Message != "" {
-      return diag.FromErr(symbiosisErr)
-    }
-    return append(diags, diag.Diagnostic{
-      Severity: diag.Error,
-      Summary:  "Unable to create cluster",
-      Detail:   "Unknown error",
-    })
-  }
-  json := resp.Result().(*PostClusterPayload)
-  d.SetId(json.Name)
+	resp, err := api.R().SetBody(input).SetResult(PostClusterPayload{}).SetError(SymbiosisApiError{}).ForceContentType("application/json").Post("rest/v1/cluster")
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if resp.StatusCode() != 200 {
+		symbiosisErr := resp.Error().(*SymbiosisApiError)
+		if symbiosisErr.Message != "" {
+			return diag.FromErr(symbiosisErr)
+		}
+		return append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Unable to create cluster",
+			Detail:   "Unknown error",
+		})
+	}
+	json := resp.Result().(*PostClusterPayload)
+	d.SetId(json.Name)
 
-  if d.Get("wait_until_initialized").(bool) {
-    err = resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
-      resp, err := client.describeCluster(json.Name)
+	if d.Get("wait_until_initialized").(bool) {
+		err = resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+			resp, err := client.describeCluster(json.Name)
 
-      if err != nil {
-        return resource.NonRetryableError(fmt.Errorf("Error describing cluster: %s", err))
-      }
+			if err != nil {
+				return resource.NonRetryableError(fmt.Errorf("Error describing cluster: %s", err))
+			}
 
-      if resp.State != "ACTIVE" {
-        return resource.RetryableError(fmt.Errorf("expected instance to be active but was in state %s", resp.State))
-      }
+			if resp.State != "ACTIVE" {
+				return resource.RetryableError(fmt.Errorf("expected instance to be active but was in state %s", resp.State))
+			}
 
-      return nil
-    })
-    if err != nil {
-      return diag.FromErr(err)
-    }
-  }
+			return nil
+		})
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
 
-  return diags
+	return diags
 }
 
 func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {


### PR DESCRIPTION
Note: Changing the version requires a `forceNew` for the time being.

fixes #1 